### PR TITLE
Improve the address prefixes & add payout estimation

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -96,6 +96,14 @@ Explanation for each field:
     /* How many seconds until we consider a miner disconnected. */
     "minerTimeout": 900,
 
+    /* These cryptonote address prefixes are used to check whether the
+       miner supplied a valid address. The values below are for sumokoin
+       wallet and subaddresses. If you use a different coin than you must
+       update the values here. */
+    "allowedMinerAddressPrefixes": [
+      "2864026", "536986"
+    ],
+
     "ports": [
         {
             "port": 3333, //Port for mining apps to connect to

--- a/USAGE.md
+++ b/USAGE.md
@@ -179,9 +179,12 @@ Explanation for each field:
     "minPayment": 2000000000, //miner balance required before sending payment
     "maxTransactionAmount": 500000000000, //split transactions by this amount(to prevent "too big transaction" error)
     "denomination": 10000000, //truncate to this precision and store remainder
-	"useDynamicTransferFee": true, // use (simple) dynamic transfer fee
-	"transferFeePerPayee": 4000000, // dynamic transfer fee per payee/transaction
-	"minerPayFee": true // miner pays (dynamic) transfer fee instead of pool owner 
+  	"useDynamicTransferFee": true, // use (simple) dynamic transfer fee
+  	"transferFeePerPayee": 4000000, // dynamic transfer fee per payee/transaction
+  	"minerPayFee": true, // miner pays (dynamic) transfer fee instead of pool owner 
+    // When the block reward is a non-zero value; it will be used to provide a
+    // payout estimate in the miner statistics.
+    "blockReward": 0
 },
 
 /* Module that monitors the submitted block maturities and manages rounds. Confirmed

--- a/config_sumokoin.json
+++ b/config_sumokoin.json
@@ -111,7 +111,8 @@
         "denomination": 10000000,
         "useDynamicTransferFee": true,
         "transferFeePerPayee": 4000000,
-        "minerPayFee": true
+        "minerPayFee": true,
+        "blockReward": 36.45
     },
 
     "blockUnlocker": {

--- a/config_sumokoin.json
+++ b/config_sumokoin.json
@@ -22,6 +22,9 @@
         "poolAddress": "Sumoo64zh7dRFyB8dgDWZMLmzKBgGXYWZCG4NBF2VcvzEuiSQpMjyyiYJ1Ra696pZu56PPFQNBDdB1rZjyeX1RVKeWZgHg7pTxj",
         "blockRefreshInterval": 1000,
         "minerTimeout": 900,
+        "allowedMinerAddressPrefixes": [
+          "2864026", "536986"
+        ],
         "ports": [
             {
                 "port": 3333,

--- a/lib/api.js
+++ b/lib/api.js
@@ -234,18 +234,20 @@ function handleMinerStats(urlParts, response){
         var stats = replies[0];
         stats.hashrate = minerStats[address];
 
-        // Provide a rough estimation what the address owner would earn if
-        // the a block would be found and payed out right now.
-        var totalShares = 0;
-        var myShares = 0;
-        for (var key in replies[2]) {
-          totalShares += parseInt(replies[2][key]);
-          if (key == address) {
-            myShares = parseInt(replies[2][key]);
+        if (config.payments.blockReward != 0) {
+          // Provide a rough estimation what the address owner would earn if
+          // the a block would be found and payed out right now.
+          var totalShares = 0;
+          var myShares = 0;
+          for (var key in replies[2]) {
+            totalShares += parseInt(replies[2][key]);
+            if (key == address) {
+              myShares = parseInt(replies[2][key]);
+            }
           }
+          var payout_estimate = (myShares / totalShares) * config.payments.blockReward;
+          stats.payout_estimate = payout_estimate.toFixed(9);
         }
-        var payout_estimate = (myShares / totalShares) * config.payments.blockReward;
-        stats.payout_estimate = payout_estimate.toFixed(9);
 
         charts.getUserChartsData(address, replies[1], function(error, chartsData) {
             response.end(JSON.stringify({

--- a/lib/api.js
+++ b/lib/api.js
@@ -237,7 +237,8 @@ function handleMinerStats(urlParts, response){
     else{
         redisClient.multi([
             ['hgetall', config.coin + ':workers:' + address],
-            ['zrevrange', config.coin + ':payments:' + address, 0, config.api.payments - 1, 'WITHSCORES']
+            ['zrevrange', config.coin + ':payments:' + address, 0, config.api.payments - 1, 'WITHSCORES'],
+            ['hgetall', config.coin + ':shares:roundCurrent']
         ]).exec(function(error, replies){
             if (error || !replies[0]){
                 response.end(JSON.stringify({error: 'not found'}));
@@ -245,6 +246,20 @@ function handleMinerStats(urlParts, response){
             }
             var stats = replies[0];
             stats.hashrate = minerStats[address];
+
+            // Provide a rough estimation what the address owner would earn if
+            // the a block would be found and payed out right now.
+            var totalShares = 0;
+            var myShares = 0;
+            for (var key in replies[2]) {
+              totalShares += parseInt(replies[2][key]);
+              if (key == address) {
+                myShares = parseInt(replies[2][key]);
+              }
+            }
+            var payout_estimate = (myShares / totalShares) * config.payments.blockReward;
+            stats.payout_estimate = payout_estimate.toFixed(2);
+
             charts.getUserChartsData(address, replies[1], function(error, chartsData) {
                 response.end(JSON.stringify({
                     stats: stats,

--- a/lib/api.js
+++ b/lib/api.js
@@ -222,53 +222,39 @@ function handleMinerStats(urlParts, response){
     response.write('\n');
     var address = urlParts.query.address;
 
-    if (urlParts.query.longpoll === 'true'){
-        redisClient.exists(config.coin + ':workers:' + address, function(error, result){
-            if (!result){
-                response.end(JSON.stringify({error: 'not found'}));
-                return;
-            }
-            addressConnections[address] = response;
-            response.on('finish', function(){
-                delete addressConnections[address];
-            })
-        });
-    }
-    else{
-        redisClient.multi([
-            ['hgetall', config.coin + ':workers:' + address],
-            ['zrevrange', config.coin + ':payments:' + address, 0, config.api.payments - 1, 'WITHSCORES'],
-            ['hgetall', config.coin + ':shares:roundCurrent']
-        ]).exec(function(error, replies){
-            if (error || !replies[0]){
-                response.end(JSON.stringify({error: 'not found'}));
-                return;
-            }
-            var stats = replies[0];
-            stats.hashrate = minerStats[address];
+    redisClient.multi([
+        ['hgetall', config.coin + ':workers:' + address],
+        ['zrevrange', config.coin + ':payments:' + address, 0, config.api.payments - 1, 'WITHSCORES'],
+        ['hgetall', config.coin + ':shares:roundCurrent']
+    ]).exec(function(error, replies){
+        if (error || !replies[0]){
+            response.end(JSON.stringify({error: 'not found'}));
+            return;
+        }
+        var stats = replies[0];
+        stats.hashrate = minerStats[address];
 
-            // Provide a rough estimation what the address owner would earn if
-            // the a block would be found and payed out right now.
-            var totalShares = 0;
-            var myShares = 0;
-            for (var key in replies[2]) {
-              totalShares += parseInt(replies[2][key]);
-              if (key == address) {
-                myShares = parseInt(replies[2][key]);
-              }
-            }
-            var payout_estimate = (myShares / totalShares) * config.payments.blockReward;
-            stats.payout_estimate = payout_estimate.toFixed(2);
+        // Provide a rough estimation what the address owner would earn if
+        // the a block would be found and payed out right now.
+        var totalShares = 0;
+        var myShares = 0;
+        for (var key in replies[2]) {
+          totalShares += parseInt(replies[2][key]);
+          if (key == address) {
+            myShares = parseInt(replies[2][key]);
+          }
+        }
+        var payout_estimate = (myShares / totalShares) * config.payments.blockReward;
+        stats.payout_estimate = payout_estimate.toFixed(9);
 
-            charts.getUserChartsData(address, replies[1], function(error, chartsData) {
-                response.end(JSON.stringify({
-                    stats: stats,
-                    payments: replies[1],
-                    charts: chartsData
-                }));
-            });
+        charts.getUserChartsData(address, replies[1], function(error, chartsData) {
+            response.end(JSON.stringify({
+                stats: stats,
+                payments: replies[1],
+                charts: chartsData
+            }));
         });
-    }
+    });
 }
 
 /* Call 'callback' when we've seen a miner for 'address' using 'ip' */

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -51,11 +51,6 @@ var shareTrustMinFloat = shareTrustEnabled ? config.poolServer.shareTrust.min / 
 
 var banningEnabled = config.poolServer.banning && config.poolServer.banning.enabled;
 
-// The Sumo address prefixes we use to detect malformed wallet addresses.
-var sumoWalletBase58AddressPrefix = '2864026';
-var sumoWalletBase58SubAddressPrefix = '536986';
-
-
 setInterval(function(){
     var now = Date.now() / 1000 | 0;
     for (var minerId in connectedMiners){
@@ -584,12 +579,12 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                 }
             }
 
-            var addressPrefix = cnUtil.address_decode(new Buffer(login));
-            if (addressPrefix != sumoWalletBase58AddressPrefix && addressPrefix != sumoWalletBase58SubAddressPrefix) {
+            // Check that the address prefix is sane.
+            var addressPrefix = cnUtil.address_decode(new Buffer(login)).toString();
+            if (config.poolServer.allowedMinerAddressPrefixes.indexOf(addressPrefix) == -1) {
                 sendReply('invalid address used');
                 return;
             }
-
 
             var minerId = utils.uid();
             miner = new Miner(minerId, login, params.pass, ip, difficulty, noRetarget, pushMessage);

--- a/website/pages/home.html
+++ b/website/pages/home.html
@@ -259,8 +259,8 @@
             <!-- <div class="yourStats"><i class="fa fa-key"></i> Address: <span id="yourAddressDisplay"></span></div> -->
             <div class="yourStats"><i class="fa fa-bank"></i> Pending Balance: <span id="yourPendingBalance"></span></div>
             <div class="yourStats"><i class="fa fa-money"></i> Total Paid: <span id="yourPaid"></span></div>
-            <div class="yourStats"><i class="fa fa-money"></i> Next payment est.:
-                <span id="yourNextPaymentEstimate"></span>
+            <div class="yourStats"><i class="fa fa-money"></i> Next payment: 
+                <span id="yourNextPaymentEstimate"> SUMO</span>
                 <span data-toggle="tooltip" title="A rough estimate of the payment you'd get if a block was found RIGHT NOW."
                       class="fa fa-question-circle">
                 </span>
@@ -507,12 +507,11 @@
         if (xhrAddressPoll) xhrAddressPoll.abort();
         if (addressTimeout) clearTimeout(addressTimeout);
 
-        function fetchAddressStats(longpoll){
+        function fetchAddressStats(){
             xhrAddressPoll = $.ajax({
                 url: api + '/stats_address',
                 data: {
                     address: address,
-                    longpoll: longpoll
                 },
                 dataType: 'json',
                 cache: 'false',
@@ -527,7 +526,7 @@
 
                         if (addressTimeout) clearTimeout(addressTimeout);
                         addressTimeout = setTimeout(function(){
-                            fetchAddressStats(false);
+                            fetchAddressStats();
                         }, 2000);
 
                         return;
@@ -564,7 +563,7 @@
 
                     docCookies.setItem('mining_address', address, Infinity);
 
-                    fetchAddressStats(true);
+                    fetchAddressStats();
                     
                 },
                 error: function(e){
@@ -573,13 +572,13 @@
 
                     if (addressTimeout) clearTimeout(addressTimeout);
                     addressTimeout = setTimeout(function(){
-                        fetchAddressStats(false);
+                        fetchAddressStats();
                     }, 2000);
                     
                 }
             });
         }
-        fetchAddressStats(false);
+        fetchAddressStats();
     });
     
     var urlWalletAddress = location.search.split('wallet=')[1] || 0;

--- a/website/pages/home.html
+++ b/website/pages/home.html
@@ -52,6 +52,9 @@
     .yourStats{
         display: none;
     }
+    .nextPaymentEstimate {
+        display: none;
+    }
     #yourAddressDisplay{
         display: inline-block;
         max-width: 100%;
@@ -259,7 +262,7 @@
             <!-- <div class="yourStats"><i class="fa fa-key"></i> Address: <span id="yourAddressDisplay"></span></div> -->
             <div class="yourStats"><i class="fa fa-bank"></i> Pending Balance: <span id="yourPendingBalance"></span></div>
             <div class="yourStats"><i class="fa fa-money"></i> Total Paid: <span id="yourPaid"></span></div>
-            <div class="yourStats"><i class="fa fa-money"></i> Next payment: 
+            <div id="nextPaymentEstimate" class="yourStats"><i class="fa fa-money"></i> Next payment: 
                 <span id="yourNextPaymentEstimate"> SUMO</span>
                 <span data-toggle="tooltip" title="A rough estimate of the payment you'd get if a block was found RIGHT NOW."
                       class="fa fa-question-circle">
@@ -544,7 +547,13 @@
                     updateText('yourHashes', (data.stats.hashes || 0).toString());
                     updateText('yourPaid', getReadableCoins(data.stats.paid));
                     updateText('yourPendingBalance', getReadableCoins(data.stats.balance));
-                    updateText('yourNextPaymentEstimate', data.stats.payout_estimate);
+
+                    if (data.stats.payout_estimate != undefined) {
+                        if (!$('#nextPaymentEstimate').is(":visible")) {
+                            $('#nextPaymentEstimate').show();
+                        }
+                        updateText('yourNextPaymentEstimate', data.stats.payout_estimate);
+                    }
 
                     renderPayments(data.payments);
 

--- a/website/pages/home.html
+++ b/website/pages/home.html
@@ -259,6 +259,12 @@
             <!-- <div class="yourStats"><i class="fa fa-key"></i> Address: <span id="yourAddressDisplay"></span></div> -->
             <div class="yourStats"><i class="fa fa-bank"></i> Pending Balance: <span id="yourPendingBalance"></span></div>
             <div class="yourStats"><i class="fa fa-money"></i> Total Paid: <span id="yourPaid"></span></div>
+            <div class="yourStats"><i class="fa fa-money"></i> Next payment est.:
+                <span id="yourNextPaymentEstimate"></span>
+                <span data-toggle="tooltip" title="A rough estimate of the payment you'd get if a block was found RIGHT NOW."
+                      class="fa fa-question-circle">
+                </span>
+            </div>
             <div class="yourStats"><i class="fa fa-clock-o"></i> Last Share Submitted: <span id="yourLastShare"></span></div>
             <div class="yourStats"><i class="fa fa-tachometer"></i> Hash Rate: <span id="yourHashrateHolder"></span></div>
             <div class="yourStats"><i class="fa fa-cloud-upload"></i> Total Hashes Submitted: <span id="yourHashes"></span></div>
@@ -539,6 +545,7 @@
                     updateText('yourHashes', (data.stats.hashes || 0).toString());
                     updateText('yourPaid', getReadableCoins(data.stats.paid));
                     updateText('yourPendingBalance', getReadableCoins(data.stats.balance));
+                    updateText('yourNextPaymentEstimate', data.stats.payout_estimate);
 
                     renderPayments(data.payments);
 


### PR DESCRIPTION
_(I fucked up my branch and intended to have two PRs for these three changess)_

It's bad to have these values hardcoded because they are sumo specific and prevent other coins from using our pool software. This move the values we check on to the config.

The second change add a payout estimate to the miner stats overview.

The third change is that the longpoll option is removed from the address stats collection handler. It is much cleaner without it and in terms of performance not a big difference.