### PR TITLE
Initial version of the worker stats

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -259,7 +259,9 @@ function handleMinerStats(urlParts, response){
         for (var i=0; i<replies[3].length; i++) {
           var key = replies[3][i];
           var nameOffset = key.indexOf('+');
-          workers.push(key.substr(nameOffset + 1));
+          if (nameOffset != -1) {
+            workers.push(key.substr(nameOffset + 1));
+          }
         }
 
         charts.getUserChartsData(address, replies[1], function(error, chartsData) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -229,7 +229,8 @@ function handleMinerStats(urlParts, response){
     redisClient.multi([
         ['hgetall', config.coin + ':workers:' + address],
         ['zrevrange', config.coin + ':payments:' + address, 0, config.api.payments - 1, 'WITHSCORES'],
-        ['hgetall', config.coin + ':shares:roundCurrent']
+        ['hgetall', config.coin + ':shares:roundCurrent'],
+        ['keys', config.coin + ':charts:hashrate:' + address + '*']
     ]).exec(function(error, replies){
         if (error || !replies[0]){
             response.end(JSON.stringify({error: 'not found'}));
@@ -253,13 +254,37 @@ function handleMinerStats(urlParts, response){
           stats.payout_estimate = payout_estimate.toFixed(9);
         }
 
+        // Grab the worker names.
+        var workers = [];
+        for (var i=0; i<replies[3].length; i++) {
+          var key = replies[3][i];
+          var nameOffset = key.indexOf('+');
+          workers.push(key.substr(nameOffset + 1));
+        }
+
         charts.getUserChartsData(address, replies[1], function(error, chartsData) {
             response.end(JSON.stringify({
                 stats: stats,
                 payments: replies[1],
-                charts: chartsData
+                charts: chartsData,
+                workers: workers
             }));
         });
+    });
+}
+
+function handleWorkerStats(urlParts, response){
+    response.writeHead(200, {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json',
+        'Connection': 'keep-alive'
+    });
+    response.write('\n');
+    var address = urlParts.query.address;
+
+    charts.getUserChartsData(address, [], function(error, chartsData) {
+      response.end(JSON.stringify({ charts: chartsData }));
     });
 }
 
@@ -887,6 +912,9 @@ if(config.api.ssl == true)
           case '/stats_address':
               handleMinerStats(urlParts, response);
               break;
+          case '/stats_worker':
+              handleWorkerStats(urlParts, response);
+              break;
           case '/get_payments':
               handleGetPayments(urlParts, response);
               break;
@@ -1002,6 +1030,9 @@ var server = http.createServer(function(request, response){
             break;
         case '/stats_address':
             handleMinerStats(urlParts, response);
+            break;
+        case '/stats_worker':
+            handleWorkerStats(urlParts, response);
             break;
         case '/get_payments':
             handleGetPayments(urlParts, response);

--- a/lib/api.js
+++ b/lib/api.js
@@ -83,7 +83,11 @@ function collectStats(){
 
                 for (var miner in minersHashrate){
                     var shares = minersHashrate[miner];
-                    totalShares += shares;
+                    // Do not count the hashrates of individual workers. Instead
+                    // only use the shares where miner == wallet address.
+                    if (miner.indexOf('+') != -1) {
+                      totalShares += shares;
+                    }
                     minersHashrate[miner] = Math.round(shares / config.api.hashrateWindow);
                     minerStats[miner] = getReadableHashRateString(minersHashrate[miner]);
                 }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -278,7 +278,7 @@ var VarDiff = (function(){
     };
 })();
 
-function Miner(id, login, pass, ip, startingDiff, noRetarget, pushMessage){
+function Miner(id, login, workerName, pass, ip, startingDiff, noRetarget, pushMessage){
     this.id = id;
     this.login = login;
     this.pass = pass;
@@ -287,6 +287,7 @@ function Miner(id, login, pass, ip, startingDiff, noRetarget, pushMessage){
     this.heartbeat();
     this.noRetarget = noRetarget;
     this.difficulty = startingDiff;
+    this.workerName = workerName;
     this.validJobs = [];
 
     // Vardiff related variables
@@ -443,6 +444,7 @@ function recordShareData(miner, job, shareDiff, blockCandidate, hashHex, shareTy
     var redisCommands = [
         ['hincrby', config.coin + ':shares:roundCurrent', miner.login, job.difficulty],
         ['zadd', config.coin + ':hashrate', dateNowSeconds, [job.difficulty, miner.login, dateNow].join(':')],
+        ['zadd', config.coin + ':hashrate', dateNowSeconds, [job.difficulty, miner.login + '+' + miner.workerName, dateNow].join(':')],
         ['hincrby', config.coin + ':workers:' + miner.login, 'hashes', job.difficulty],
         ['hset', config.coin + ':workers:' + miner.login, 'lastShare', dateNowSeconds],
         ['hset', uniqueWorkerKey, 'lastShare', dateNowSeconds],
@@ -565,7 +567,15 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
             }
 
             var difficulty = portData.difficulty;
+            var workerName = "unknown";
             var noRetarget = false;
+            // Grep the worker name.
+            var workerNameCharPos = login.indexOf('+');
+            if (workerNameCharPos != -1) {
+              workerName = login.substr(workerNameCharPos + 1);
+              login = login.substr(0, workerNameCharPos);
+              log('info', logSystem, 'Miner %s uses worker name: %s',  [login, workerName]);
+            }
             if(config.poolServer.fixedDiff.enabled) {
                 var fixedDiffCharPos = login.indexOf(config.poolServer.fixedDiff.addressSeparator);
                 if(fixedDiffCharPos != -1) {
@@ -587,7 +597,7 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
             }
 
             var minerId = utils.uid();
-            miner = new Miner(minerId, login, params.pass, ip, difficulty, noRetarget, pushMessage);
+            miner = new Miner(minerId, login, workerName, params.pass, ip, difficulty, noRetarget, pushMessage);
             connectedMiners[minerId] = miner;
             
             sendReply(null, {
@@ -595,7 +605,7 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                 job: miner.getJob(),
                 status: 'OK'
             });
-            log('info', logSystem, 'Miner connected %s@%s',  [params.login, miner.ip]);
+            log('info', logSystem, 'Miner connected %s@%s',  [login, miner.ip]);
             break;
         case 'getjob':
             if (!miner){

--- a/website/index.html
+++ b/website/index.html
@@ -371,10 +371,6 @@
                     <i class="fa fa-home"></i> Home
                 </a></li>
 
-                <li><a class="hot_link" data-page="getting_started.html" href="#getting_started">
-                    <i class="fa fa-rocket"></i> Getting Started
-                </a></li>
-
                 <li><a class="hot_link" data-page="pool_blocks.html" href="#pool_blocks">
                     <i class="fa fa-cubes"></i> Pool Blocks
                 </a></li>
@@ -383,9 +379,26 @@
                     <i class="fa fa-paper-plane-o"></i> Payments
                 </a></li>
 
-                <li><a class="hot_link" data-page="support.html" href="#support">
-                    <i class="fa fa-comments"></i> Support
+                <li><a class="hot_link" data-page="worker_stats.html" href="#worker_stats">
+                    <i class="fa fa-tachometer"></i> Worker Stats
                 </a></li>
+
+                <li class="dropdown">
+                  <a class="dropdown-toggle" data-toggle="dropdown" href="#"><i class="fa fa-comments"></i> Support
+                    <span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu">
+                    <li>
+                      <a class="hot_link" data-page="getting_started.html" href="#getting_started">
+                        <i class="fa fa-rocket"></i> Getting Started </a>
+                    </li>
+                    <li>
+                      <a class="hot_link" data-page="support.html" href="#support">
+                        <i class="fa fa-comments"></i> Contact </a>
+                    </li>
+                  </ul>
+                </li>
+
                 <li><a class="hot_link" data-page="settings.html" href="#settings">
                     <i class="fa fa-cog"></i> Settings
                 </a></li>

--- a/website/pages/worker_stats.html
+++ b/website/pages/worker_stats.html
@@ -112,7 +112,7 @@ function getWorkerGraphData(worker, address, dataHandler) {
 <h1>Individual worker stats</h1>
 <br>
 To show individual worker statistics; you will need to configure your miner with
-a worker name. Simple append the worker name you like to your wallet address
+a worker name. Simply append the worker name you like to your wallet address
 using the following format:
 <br>
 <i>wallet_address+workername</i><br>

--- a/website/pages/worker_stats.html
+++ b/website/pages/worker_stats.html
@@ -1,12 +1,34 @@
-<h2>Contact</h2>
-<script src="https://cdn.plot.ly/plotly-1.2.0.min.js"></script>
 
 <script>
+
+function loadScript(url, callback){
+  var script = document.createElement("script")
+    script.type = "text/javascript";
+
+  if (script.readyState){  //IE
+    script.onreadystatechange = function(){
+      if (script.readyState == "loaded" ||
+          script.readyState == "complete"){
+        script.onreadystatechange = null;
+        callback();
+      }
+    };
+  } else {  //Others
+    script.onload = function(){
+      callback();
+    };
+  }
+
+  script.src = url;
+  document.getElementsByTagName("head")[0].appendChild(script);
+}
+
 $('#addressSetButton').click(function(){
   var address = $('#yourAddress').val();
   fetchAddressWorkers(address);
 });
 
+// Fetches the workers that are known for an address and creates the graphs.
 function fetchAddressWorkers(address) {
   $.ajax({
     url: api + '/stats_address',
@@ -15,24 +37,37 @@ function fetchAddressWorkers(address) {
     },
     dataType: 'json',
     cache: 'false',
-    success: function(data){                    
-      var first = true;
+    success: function(data){
       for (var i=0; i<data.workers.length; i++) {
-        getWorkerGraphData(data.workers[i], address, function(graphData) {
-          if (first) {
-            Plotly.newPlot('worker_chart', graphData);
-            first = false;
+        getWorkerGraphData(data.workers[i], address, function(graphData, rangeMax) {
+          var new_id = 'chart_' + graphData[0].name;
+          var $template = $("#worker_chart").clone().prop('id', new_id);
+          if (graphData[0].y.length < 5) {
+            $template.append('<br>Not enough data yet for worker: ' + graphData[0].name);
+            $template.appendTo("#graphs");
           } else {
-            Plotly.update('worker_chart', graphData);
+            var layout = {
+              title: 'Hashrate worker: ' + graphData[0].name,
+              autosize: false,
+              width: 1000,
+              height: 500,
+              yaxis: {
+                autorange: false,
+                range: [0, rangeMax + 500],
+                type: 'linear'
+              }
+            }
+            $template.appendTo("#graphs");
+            Plotly.newPlot(new_id, graphData, layout);
           }
+          $('#' + new_id).show();
         });
       }
-
-      $("#worker_chart").show();
     }
   });
 }
 
+// Gets worker graph data.
 function getWorkerGraphData(worker, address, dataHandler) {
   var worker_address = address + '+' + worker;
   $.ajax({
@@ -42,38 +77,71 @@ function getWorkerGraphData(worker, address, dataHandler) {
     },
     dataType: 'json',
     cache: 'false',
-    success: function(data){                    
-      var $template = $("#worker_chart").html();
+    success: function(data){
       var graphData = {
         names: [],
         values: []
       };
 
+      var rangeMax = 0;
       for (var i = 0; i< data['charts']['hashrate'].length; i++) {
         xy = data['charts']['hashrate'][i];
         graphData.names.push(new Date(xy[0]*1000).toUTCString());
+        if (xy[1] > rangeMax) {
+          rangeMax = xy[1];
+        }
         graphData.values.push(xy[1]);
       }
 
-      dataHandler([{ x: graphData.names, y: graphData.values, type: 'scatter' }]);
+      dataHandler([{
+        x: graphData.names,
+        y: graphData.values,
+        type: 'scatter',
+        name: worker,
+        mode: 'lines',
+        fill: 'tonexty',
+        connectgaps: true,
+        autosize: false
+      }], rangeMax);
     }
   });
 }
 </script>
 
+<h1>Individual worker stats</h1>
+<br>
+To show individual worker statistics; you will need to configure your miner with a worker name. The format for this is the following:
+<i>wallet_address+workername</i><br>
+<br>
+
+Note: that it might take a few hours before the stats on this page start to show meaningful data.
+<br><br>
 
 <div class="form-group">
   <label class="col-sm-2 col-form-label col-form-label-lg" for="yourAddress">Sumo address:</label>
-  <div class="col-sm-10">
+  <div class="col-sm-8">
     <input class="form-control" id="yourAddress" type="text" placeholder="Enter Your Address">
   </div>
   <span>
     <button class="btn btn-default" type="button" id="addressSetButton">
-      <span><i class="fa fa-check"></i> Go</span>
+      <span><i class="fa fa-check"></i> Show</span>
     </button>
   </span>
 </div>
+<hr>
 
-<div id="worker_chart" style="width:600px;height:250px; display:none"></div>
+<div id="worker_chart" style="display:none"></div>
 <div id="graphs">
 </div>
+
+<script>
+loadScript("https://cdn.plot.ly/plotly-1.2.0.min.js", function() {
+var urlWalletAddress = location.search.split('wallet=')[1] || 0;
+var address = urlWalletAddress || docCookies.getItem('mining_address');
+
+if (address) {
+	$('#yourAddress').val(address);
+	fetchAddressWorkers(address);
+}
+});
+</script>

--- a/website/pages/worker_stats.html
+++ b/website/pages/worker_stats.html
@@ -111,11 +111,15 @@ function getWorkerGraphData(worker, address, dataHandler) {
 
 <h1>Individual worker stats</h1>
 <br>
-To show individual worker statistics; you will need to configure your miner with a worker name. The format for this is the following:
+To show individual worker statistics; you will need to configure your miner with
+a worker name. Simple append the worker name you like to your wallet address
+using the following format:
+<br>
 <i>wallet_address+workername</i><br>
 <br>
 
-Note: that it might take a few hours before the stats on this page start to show meaningful data.
+Note: that it might take a few hours before the stats on this page start to show
+meaningful data. It's on our TODO list to speed this up.
 <br><br>
 
 <div class="form-group">

--- a/website/pages/worker_stats.html
+++ b/website/pages/worker_stats.html
@@ -24,6 +24,7 @@ function loadScript(url, callback){
 }
 
 $('#addressSetButton').click(function(){
+  $("#graphs").empty();
   var address = $('#yourAddress').val();
   fetchAddressWorkers(address);
 });

--- a/website/pages/worker_stats.html
+++ b/website/pages/worker_stats.html
@@ -1,0 +1,79 @@
+<h2>Contact</h2>
+<script src="https://cdn.plot.ly/plotly-1.2.0.min.js"></script>
+
+<script>
+$('#addressSetButton').click(function(){
+  var address = $('#yourAddress').val();
+  fetchAddressWorkers(address);
+});
+
+function fetchAddressWorkers(address) {
+  $.ajax({
+    url: api + '/stats_address',
+    data: {
+      address: address,
+    },
+    dataType: 'json',
+    cache: 'false',
+    success: function(data){                    
+      var first = true;
+      for (var i=0; i<data.workers.length; i++) {
+        getWorkerGraphData(data.workers[i], address, function(graphData) {
+          if (first) {
+            Plotly.newPlot('worker_chart', graphData);
+            first = false;
+          } else {
+            Plotly.update('worker_chart', graphData);
+          }
+        });
+      }
+
+      $("#worker_chart").show();
+    }
+  });
+}
+
+function getWorkerGraphData(worker, address, dataHandler) {
+  var worker_address = address + '+' + worker;
+  $.ajax({
+    url: api + '/stats_worker',
+    data: {
+      address: worker_address,
+    },
+    dataType: 'json',
+    cache: 'false',
+    success: function(data){                    
+      var $template = $("#worker_chart").html();
+      var graphData = {
+        names: [],
+        values: []
+      };
+
+      for (var i = 0; i< data['charts']['hashrate'].length; i++) {
+        xy = data['charts']['hashrate'][i];
+        graphData.names.push(new Date(xy[0]*1000).toUTCString());
+        graphData.values.push(xy[1]);
+      }
+
+      dataHandler([{ x: graphData.names, y: graphData.values, type: 'scatter' }]);
+    }
+  });
+}
+</script>
+
+
+<div class="form-group">
+  <label class="col-sm-2 col-form-label col-form-label-lg" for="yourAddress">Sumo address:</label>
+  <div class="col-sm-10">
+    <input class="form-control" id="yourAddress" type="text" placeholder="Enter Your Address">
+  </div>
+  <span>
+    <button class="btn btn-default" type="button" id="addressSetButton">
+      <span><i class="fa fa-check"></i> Go</span>
+    </button>
+  </span>
+</div>
+
+<div id="worker_chart" style="width:600px;height:250px; display:none"></div>
+<div id="graphs">
+</div>


### PR DESCRIPTION
This is the initial version of the worker stats page.

- Allows a worker name to be configured by adding a +workername suffix to the wallet address
- Stores the hashrate for these workernames
- Shows graphs for each worker

I tried to keep this as little intrusive as possible. The code utilizes the existing charts thread that runs every 30 minutes to estimate the worker (and existing wallet) hashrates.  This 30 minutes is not ideal so in a next change I will look into getting faster hashrate updates in the graph.

![screenshot - 12182017 - 07 44 51 pm](https://user-images.githubusercontent.com/12248144/34125312-20f81bae-e436-11e7-9402-ef88a23a29fe.png)
