### PR TITLE
Fix for other coin daemon with outdated json parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-An updated cryptonote-sumokoin-pool fork
+An updated cryptonight/cryptonote pool fork
 ========================================
 
 High performance Node.js (with native C addons) mining pool for CryptoNote based coins such as Bytecoin, DuckNote, Monero, QuazarCoin, Boolberry, Dashcoin, Sumokoin etc..
@@ -89,15 +89,12 @@ individual worker.
 
 ## Pools Using This Software
 
-* https://pool.sumokoin.com
-* https://pool.sumokoin.ch
-
-More pools can be found on [sumopools.com](https://www.sumopools.com)
+* https://www.leafpool.com
 
 ## Usage
 
 Visit the usage guide here.
-[Visit the usage guide here](https://github.com/SadBatman/cryptonote-sumokoin-pool/blob/master/USAGE.md)
+[Visit the usage guide here](https://github.com/CryptoMinerOS/crypto-pool/blob/master/USAGE.md)
 
 
 ## License

--- a/lib/api.js
+++ b/lib/api.js
@@ -782,11 +782,13 @@ function handleHealthRequest(response) {
     async.parallel({
         monitoring: getMonitoringData
     }, function(error, result) {
-        var status = 'NOT OK';
-	if (result['monitoring']['daemon']['lastStatus'] == "ok" &&
-            result['monitoring']['wallet']['lastStatus'] == "ok") {
-            status = 'OK';
-        }
+	var status = 'NOT OK';
+    	if (result['monitoring']['daemon'] &&
+      		result['monitoring']['daemon']['lastStatus'] == "ok" &&
+      		result['monitoring']['wallet'] &&
+      		result['monitoring']['wallet']['lastStatus'] == "ok") {
+      		status = 'OK';
+    	}
         response.end(JSON.stringify({"status": status}));
     });
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -350,7 +350,7 @@ function handleSetMinerPayoutLevel(urlParts, response){
     // combination with the wallet address.
     minerSeenWithIPForAddress(address, ip, function (error, keys) {
         if (keys.length == 0 || error) {
-          response.end(JSON.stringify({'status': 'we haven\'t seen that IP for your sumo address'}));
+          response.end(JSON.stringify({'status': 'we haven\'t seen that IP for your miner address'}));
           return;
         }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -29,7 +29,9 @@ var pendingWrites = {};
 setInterval(function(){
     for (var fileName in pendingWrites){
         var data = pendingWrites[fileName];
-        fs.appendFile(fileName, data);
+        fs.appendFile(fileName, data, function (err) {
+	        if (err) throw err;     
+	    });
         delete pendingWrites[fileName];
     }
 }, config.logging.files.flushInterval * 1000);

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -847,7 +847,7 @@ function startPoolServerTcp(callback){
             key: fs.readFileSync(config.poolServer.sslKey),
             cert: fs.readFileSync(config.poolServer.sslCert)
           };
-          tls.createServer(options, socketResponder).listen(portData.port, function (error, result) {
+          tls.createServer(options, socketResponder).listen(portData.port, config.poolServer.stratumHost, function (error, result) {
             if (error) {
               log('error', logSystem, 'SSL Could not start server listening on port %d, error: $j', [portData.port, error]);
               cback(true);
@@ -858,7 +858,7 @@ function startPoolServerTcp(callback){
           });
         }
         else {
-          net.createServer(socketResponder).listen(portData.port, function (error, result) {
+          net.createServer(socketResponder).listen(portData.port, config.poolServer.stratumHost, function (error, result) {
             if (error) {
               log('error', logSystem, 'Could not start server listening on port %d, error: $j', [portData.port, error]);
               cback(true);

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -694,9 +694,12 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
             sendReply(null, {status: 'OK'});
             break;
         case 'keepalived' :
+            if (!miner){
+                sendReply('Unauthenticated');
+                return;
+            }
             miner.heartbeat()
-            sendReply(null, { status:'KEEPALIVED'
-            });
+            sendReply(null, { status:'KEEPALIVED'});
             break;
         default:
             sendReply("invalid method");

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -502,7 +502,7 @@ function processShare(miner, job, blockTemplate, nonce, resultHash){
     }
     else {
         convertedBlob = cnUtil.convert_blob(shareBuffer);
-        hash = cryptoNight(convertedBlob);
+        hash = cryptoNight(convertedBlob, convertedBlob[0] >= 7 ? convertedBlob[0] - 6 : 0);
         shareType = 'valid';
     }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -139,7 +139,7 @@ function getBlockTemplate(callback){
 }
 
 function getBlockCount(callback){
-    apiInterfaces.rpcDaemon('getblockcount', null, callback);
+    apiInterfaces.rpcDaemon('getblockcount', {}, callback);
 }
 
 function getBlockHash(callback){

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -4,7 +4,7 @@ var crypto = require('crypto');
 
 var async = require('async');
 var bignum = require('bignum');
-var multiHashing = require('multi-hashing');
+var multiHashing = require('cryptonight-hashing');
 var cnUtil = require('cryptonote-util');
 
 // Must exactly be 8 hex chars, already lowercased before test

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -51,6 +51,9 @@ var shareTrustMinFloat = shareTrustEnabled ? config.poolServer.shareTrust.min / 
 
 var banningEnabled = config.poolServer.banning && config.poolServer.banning.enabled;
 
+var addressBase58Prefix = cnUtil.address_decode(new Buffer(config.poolServer.poolAddress));  
+var integratedAddressBase58Prefix = addressBase58Prefix + 1; // Monero integraeted address prefixes are address prefix + 1      
+
 setInterval(function(){
     var now = Date.now() / 1000 | 0;
     for (var minerId in connectedMiners){
@@ -567,34 +570,66 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
             }
 
             var difficulty = portData.difficulty;
-            var workerName = "unknown";
+            var workerName = "noname";
             var noRetarget = false;
-            // Grep the worker name.
-            var workerNameCharPos = login.indexOf('+');
-            if (workerNameCharPos != -1) {
-              workerName = login.substr(workerNameCharPos + 1);
-              login = login.substr(0, workerNameCharPos);
-              log('info', logSystem, 'Miner %s uses worker name: %s',  [login, workerName]);
+            var addressSeparator = '.';
+            var fixedDiffSeparator = '+';
+            
+            if (config && config.poolServer && config.poolServer.addressSeparator) {
+                addressSeparator = config.poolServer.addressSeparator;
             }
-            if(config.poolServer.fixedDiff.enabled) {
-                var fixedDiffCharPos = login.indexOf(config.poolServer.fixedDiff.addressSeparator);
-                if(fixedDiffCharPos != -1) {
-                    noRetarget = true;
-                    difficulty = login.substr(fixedDiffCharPos + 1);
-                    if(difficulty < config.poolServer.varDiff.minDiff) {
-                        difficulty = config.poolServer.varDiff.minDiff;
-                    }
-                    login = login.substr(0, fixedDiffCharPos);
-                    log('info', logSystem, 'Miner difficulty fixed to %s',  [difficulty]);
+            
+            if (config && config.poolServer && config.poolServer.fixedDiff && config.poolServer.fixedDiff.addressSeparator) {
+                fixedDiffSeparator = config.poolServer.fixedDiff.addressSeparator;
+            }
+            
+            //Check if we have the fixedDiffSeparator
+            var fixedDiffCharPos = login.lastIndexOf(fixedDiffSeparator); 
+            //Yup we have the fixedDiffSeparator 
+            if ( fixedDiffCharPos != -1 ){
+                var new_diff = login.substr(fixedDiffCharPos + 1);
+                //Lets remove the diff from login
+                login = login.substr(0, fixedDiffCharPos);
+                if(config.poolServer.fixedDiff.enabled) {  
+                        noRetarget = true;
+                        difficulty = parseInt(new_diff, 10);
+                        if(difficulty === parseInt(difficulty, 10)){ // new_diff is int! It is difficulty!
+                            if(difficulty < config.poolServer.varDiff.minDiff) {
+                                difficulty = config.poolServer.varDiff.minDiff;
+                            }  
+                            log('info', logSystem, 'Miner difficulty fixed to %s',  [difficulty]); 
+                        }
                 }
             }
-
-            // Check that the address prefix is sane.
-            var addressPrefix = cnUtil.address_decode(new Buffer(login)).toString();
-            if (config.poolServer.allowedMinerAddressPrefixes.indexOf(addressPrefix) == -1) {
-                sendReply('invalid address used');
+            
+            var splittedLogin = login.split(addressSeparator);
+            
+            //TODO accept payment ID
+            if (splittedLogin.length > 2) {
+                sendReply('Too many login parameters.');
                 return;
             }
+            
+            login = splittedLogin[0];  
+            
+            if (splittedLogin.length == 2) {
+                  workerName = splittedLogin[1];
+                  if ( !(/^[0-9A-Za-z_]+$/.test(workerName)) || workerName.length > 16 ) {
+                    sendReply('Invalid worker name.');
+                    return;
+                }
+                //log('info', logSystem, 'Miner %s uses worker name: %s',  [login, workerName]);      
+            }
+                     
+            // Check that the address prefix is sane.
+            var addressPrefix = cnUtil.address_decode(new Buffer(login)).toString();
+            if (addressBase58Prefix !== addressPrefix && integratedAddressBase58Prefix !== addressPrefix){
+                //Invalid address is used lets double check using the allowedMinerAddressPrefixes
+                if (config.poolServer.allowedMinerAddressPrefixes.indexOf(addressPrefix) == -1) {
+                    sendReply('Invalid address used');
+                    return;
+                }      
+            }   
 
             var minerId = utils.uid();
             miner = new Miner(minerId, login, workerName, params.pass, ip, difficulty, noRetarget, pushMessage);
@@ -605,7 +640,7 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                 job: miner.getJob(),
                 status: 'OK'
             });
-            log('info', logSystem, 'Miner connected %s@%s',  [login, miner.ip]);
+            log('info', logSystem, 'Miner connected %s[%s]@%s',  [login, workerName, miner.ip]);
             break;
         case 'getjob':
             if (!miner){

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -849,22 +849,22 @@ function startPoolServerTcp(callback){
           };
           tls.createServer(options, socketResponder).listen(portData.port, config.poolServer.stratumHost, function (error, result) {
             if (error) {
-              log('error', logSystem, 'SSL Could not start server listening on port %d, error: $j', [portData.port, error]);
+              log('error', logSystem, 'SSL Could not start server listening on %s:%d, error: $j', [config.poolServer.stratumHost, portData.port, error]);
               cback(true);
               return;
             }
-            log('info', logSystem, 'SSL Started server listening on port %d', [portData.port]);
+            log('info', logSystem, 'SSL Started server listening on  %s:%d', [config.poolServer.stratumHost, portData.port]);
             cback();
           });
         }
         else {
           net.createServer(socketResponder).listen(portData.port, config.poolServer.stratumHost, function (error, result) {
             if (error) {
-              log('error', logSystem, 'Could not start server listening on port %d, error: $j', [portData.port, error]);
+              log('error', logSystem, 'Could not start server listening on %s:%d, error: $j', [config.poolServer.stratumHost, portData.port, error]);
               cback(true);
               return;
             }
-          log('info', logSystem, 'Started server listening on port %d', [portData.port]);
+          log('info', logSystem, 'Started server listening on %s:%d', [config.poolServer.stratumHost, portData.port]);
           cback();
         });
       }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "dateformat": "*",
         "base58-native": "*",
         "mailgun.js": "*",
-        "multi-hashing": "git://github.com/clintar/node-multi-hashing.git#Nan-2.0",
+        "multi-hashing": "git+https://github.com/MoneroOcean/node-cryptonight-hashing.git",
         "cryptonote-util": "git://github.com/M5M400/node-cryptonote-util.git#xmr-Nan-2.0"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "dateformat": "*",
         "base58-native": "*",
         "mailgun.js": "*",
-        "multi-hashing": "git+https://github.com/MoneroOcean/node-cryptonight-hashing.git",
+        "cryptonight-hashing": "git+https://github.com/MoneroOcean/node-cryptonight-hashing.git",
         "cryptonote-util": "git://github.com/M5M400/node-cryptonote-util.git#xmr-Nan-2.0"
     },
     "engines": {

--- a/sample_config.json
+++ b/sample_config.json
@@ -18,6 +18,8 @@
 
     "poolServer": {
         "enabled": true,
+        "stratumHost": "0.0.0.0", 
+        "addressSeparator": ".",  
         "clusterForks": "auto",
         "poolAddress": "Sumoo64zh7dRFyB8dgDWZMLmzKBgGXYWZCG4NBF2VcvzEuiSQpMjyyiYJ1Ra696pZu56PPFQNBDdB1rZjyeX1RVKeWZgHg7pTxj",
         "blockRefreshInterval": 1000,

--- a/sample_config.json
+++ b/sample_config.json
@@ -1,8 +1,8 @@
 {
-    "coin": "Sumokoin",
-    "symbol": "SUMO",
+    "coin": "CoinName",
+    "symbol": "CoinSymbol",
     "coinUnits": 1000000000,
-    "coinDifficultyTarget": 240,
+    "coinDifficultyTarget": 120,
 
     "logging": {
         "files": {
@@ -87,7 +87,7 @@
         },
         "fixedDiff": {
             "enabled": true,
-            "addressSeparator": "."
+            "addressSeparator": "+"
         },
         "shareTrust": {
             "enabled": true,
@@ -123,7 +123,7 @@
         "enabled": true,
         "interval": 30,
         "depth": 60,
-        "poolFee": 1.4,
+        "poolFee": 1.0,
         "devDonation": 0,
         "coreDevDonation": 0.1,
         "extraFeaturesDevDonation":0
@@ -136,7 +136,7 @@
         "port": 8118,
         "blocks": 30,
         "payments": 30,
-        "password": "your_password",
+        "password": "enter_password",
         "trust_proxy_ip": false
     },
 

--- a/sample_config.json
+++ b/sample_config.json
@@ -20,6 +20,7 @@
         "enabled": true,
         "stratumHost": "0.0.0.0", 
         "addressSeparator": ".",  
+        "usegetblockhash": true,
         "clusterForks": "auto",
         "poolAddress": "Sumoo64zh7dRFyB8dgDWZMLmzKBgGXYWZCG4NBF2VcvzEuiSQpMjyyiYJ1Ra696pZu56PPFQNBDdB1rZjyeX1RVKeWZgHg7pTxj",
         "blockRefreshInterval": 1000,


### PR DESCRIPTION
Other coin daemon fails to parse the json request below with a null value.

{"id":"0","jsonrpc":"2.0","method":"getblockcount","params":null}

This changes it to 

{"id":"0","jsonrpc":"2.0","method":"getblockcount","params":{}}

